### PR TITLE
Add sockets and xdebug PHP extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM php:7.4-fpm-alpine
 
 RUN apk --update upgrade \
     && apk add --no-cache autoconf automake make gcc g++ icu-dev rabbitmq-c rabbitmq-c-dev \
-    && pecl install amqp-1.9.4 \
-    && pecl install apcu-5.1.17 \
+    && pecl install \
+        amqp \
+        apcu \
+        xdebug \
     && docker-php-ext-install -j$(nproc) \
         bcmath \
         opcache \
@@ -13,4 +15,5 @@ RUN apk --update upgrade \
     && docker-php-ext-enable \
         amqp \
         apcu \
-        opcache
+        opcache \
+        xdebug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.6-fpm-alpine
+FROM php:7.4-fpm-alpine
 
 RUN apk --update upgrade \
     && apk add --no-cache autoconf automake make gcc g++ icu-dev rabbitmq-c rabbitmq-c-dev \
@@ -9,6 +9,7 @@ RUN apk --update upgrade \
         opcache \
         intl \
         pdo_mysql \
+        sockets \
     && docker-php-ext-enable \
         amqp \
         apcu \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # docker-php
-Docker PHP 
+The base image for a PHP application. 
+
+# How to build a new image/tag
+
+To build a new image we need to execute the following command, replacing `tagname` with 
+the name that you want (e.g.: `7.4.9-fpm-alpine`)
+`docker build -t dokify/php:tagname .`
+
+When the build finishes, you could upload it to the Docker Hub repository, 
+to do this, first you need to login with your Docker Hub account:
+
+`docker login`
+
+After the login, you can now upload the new image with the tag that you have generated 
+previously:
+
+`docker push dokify/php:tagname`


### PR DESCRIPTION
He añadido las extensiones de `sockets` y `xdebug` ya que parece que es necesaria para la librería `php-amqplib/php-amqplib` (subdependencia del paquete `php-enqueue/amqp-lib`) de los repos de homologation/users.
Además he añadido unas pequeñas instrucciones al readme de como generar y subir nuevas imágenes al Docker Hub.